### PR TITLE
feat: add wise as a source

### DIFF
--- a/models/facts/bank/fact_bank_transactions.sql
+++ b/models/facts/bank/fact_bank_transactions.sql
@@ -4,6 +4,7 @@ with
             dbt_utils.union_relations(
                 relations=[
                     ref("stg_bank_de_eur_amex"),
+                    ref("stg_bank_de_eur_wise"),
                     ref("stg_bank_de_eur_n26"),
                     ref("stg_bank_fr_eur_hsbcfr"),
                     ref("stg_bank_sg_eur_revolut_v1"),

--- a/models/staging/bank/gsheet/gsheet_sources.yml
+++ b/models/staging/bank/gsheet/gsheet_sources.yml
@@ -20,11 +20,25 @@ sources:
             sheet_range: de_eur_amex
             skip_leading_rows: 1
         columns:
-          - name: Datum
+          - name: datum
             data_type: STRING
-          - name: Beschreibung
+          - name: beschreibung
             data_type: STRING
-          - name: Betrag
+          - name: betrag
+            data_type: STRING
+          - name: weitere_details
+            data_type: STRING
+          - name: erscheint_auf_ihrer_abrechnung_als
+            data_type: STRING
+          - name: adresse
+            data_type: STRING
+          - name: stadt
+            data_type: STRING
+          - name: plz
+            data_type: STRING
+          - name: land
+            data_type: STRING
+          - name: betreff
             data_type: STRING
           - name: category
             data_type: STRING

--- a/models/staging/bank/gsheet/gsheet_sources.yml
+++ b/models/staging/bank/gsheet/gsheet_sources.yml
@@ -29,6 +29,59 @@ sources:
           - name: category
             data_type: STRING
 
+      - name: de_eur_wise
+        description: >
+          de_eur_wise
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1ez5NlsMezTIz0maAtRagJqkNW_NkGNtRHj9QqlzIVJ0/']
+            sheet_range: de_eur_wise
+            skip_leading_rows: 1
+        columns:
+          - name: id
+            data_type: STRING
+          - name: date
+            data_type: STRING
+          - name: amount
+            data_type: STRING
+          - name: currency
+            data_type: STRING
+          - name: description
+            data_type: STRING
+          - name: payment_reference
+            data_type: STRING
+          - name: running_balance
+            data_type: STRING
+          - name: exchange_from
+            data_type: STRING
+          - name: exchange_to
+            data_type: STRING
+          - name: exchange_rate
+            data_type: STRING
+          - name: total_fees
+            data_type: STRING
+          - name: payer_name
+            data_type: STRING
+          - name: payee_name
+            data_type: STRING
+          - name: payee_account_number
+            data_type: STRING
+          - name: merchant
+            data_type: STRING
+          - name: card_last_four_digits
+            data_type: STRING
+          - name: card_holder_full_name
+            data_type: STRING
+          - name: attachment
+            data_type: STRING
+          - name: note
+            data_type: STRING
+          - name: exchange_to_amount
+            data_type: STRING
+          - name: category
+            data_type: STRING
+
       - name: de_eur_n26
         description: >
           de_eur_n26

--- a/models/staging/bank/gsheet/stg_bank_de_eur_amex.sql
+++ b/models/staging/bank/gsheet/stg_bank_de_eur_amex.sql
@@ -3,11 +3,11 @@ with
     renamed as (
         select
             'amex_payback-cc' as source,
-            parse_date('%d/%m/%Y',{{ adapter.quote("Datum") }}) as local_date,
+            parse_date('%d/%m/%Y',{{ adapter.quote("datum") }}) as local_date,
             'EUR' as local_currency,
-            -safe_cast(replace({{ adapter.quote("Betrag") }}, ',', '.') as float64) as local_amount,
+            -safe_cast(replace({{ adapter.quote("betrag") }}, ',', '.') as float64) as local_amount,
             {{ adapter.quote("category") }} as category,
-            {{ adapter.quote("Beschreibung") }} as description
+            {{ adapter.quote("beschreibung") }} as description
         from source
     )
 select * from renamed

--- a/models/staging/bank/gsheet/stg_bank_de_eur_n26.sql
+++ b/models/staging/bank/gsheet/stg_bank_de_eur_n26.sql
@@ -7,13 +7,13 @@ with
             'EUR' as local_currency,
             safe_cast({{ adapter.quote("amount_eur") }} as float64) as local_amount,
             {{ adapter.quote("category") }},
-            concat(
+            trim(concat(
                 coalesce(cast({{ adapter.quote("payment_reference") }} as string), ''),
                 ' ',
                 coalesce(cast({{ adapter.quote("payee") }} as string), ''),
                 ' ',
                 coalesce(cast({{ adapter.quote("account_number") }} as string), '')
-            ) as description
+            )) as description
 
         from source
     )

--- a/models/staging/bank/gsheet/stg_bank_de_eur_wise.sql
+++ b/models/staging/bank/gsheet/stg_bank_de_eur_wise.sql
@@ -1,0 +1,17 @@
+with source as (
+      select * from {{ source('google_sheets', 'de_eur_wise') }}
+      where lower({{ adapter.quote("currency") }}) = 'eur'
+),
+renamed as (
+    select
+        'wise-eur' as source,
+        parse_date('%d-%m-%Y',{{ adapter.quote("date") }}) as local_date,
+        'EUR' as local_currency,
+        safe_cast({{ adapter.quote("amount") }} as float64) as local_amount,
+        {{ adapter.quote("category") }} as category,
+        {{ adapter.quote("description") }} as description
+
+    from source
+)
+select * from renamed
+  


### PR DESCRIPTION
* add wise (in EUR) as a source.
* amex DE has a new format, reflects that

following was run:

```sh
dbt run-operation stage_external_sources --vars "ext_full_refresh: true" --args "select: google_sheets.de_eur_wise"
```

```sh
dbt run-operation stage_external_sources --vars "ext_full_refresh: true" --args "select: google_sheets.de_eur_amex"
```