### PR TITLE
feat: add miles & more as a source

### DIFF
--- a/models/facts/bank/fact_bank_transactions.sql
+++ b/models/facts/bank/fact_bank_transactions.sql
@@ -4,6 +4,7 @@ with
             dbt_utils.union_relations(
                 relations=[
                     ref("stg_bank_de_eur_amex"),
+                    ref("stg_bank_de_eur_miles_more"),
                     ref("stg_bank_de_eur_n26"),
                     ref("stg_bank_de_eur_wise"),
                     ref("stg_bank_gb_gbp_wise"),

--- a/models/staging/bank/gsheet/gsheet_sources.yml
+++ b/models/staging/bank/gsheet/gsheet_sources.yml
@@ -43,6 +43,39 @@ sources:
           - name: category
             data_type: STRING
 
+      - name: de_eur_miles_more
+        description: >
+          de_eur_miles_more
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1ez5NlsMezTIz0maAtRagJqkNW_NkGNtRHj9QqlzIVJ0/']
+            sheet_range: de_eur_miles_more
+            skip_leading_rows: 1
+        columns:
+          - name: authorised_on
+            data_type: STRING
+          - name: processed_on
+            data_type: STRING
+          - name: amount
+            data_type: STRING
+          - name: currency
+            data_type: STRING
+          - name: description
+            data_type: STRING
+          - name: payment_type
+            data_type: STRING
+          - name: status
+            data_type: STRING
+          - name: amount_in_foreign_currency
+            data_type: STRING
+          - name: foreign_currency
+            data_type: STRING
+          - name: exchange_rate
+            data_type: STRING
+          - name: category
+            data_type: STRING
+
       - name: de_eur_wise
         description: >
           de_eur_wise

--- a/models/staging/bank/gsheet/stg_bank_de_eur_miles_more.sql
+++ b/models/staging/bank/gsheet/stg_bank_de_eur_miles_more.sql
@@ -1,0 +1,23 @@
+with
+    source as (
+        select *
+        from {{ source("google_sheets", "de_eur_miles_more") }}
+        where processed_on is not null
+    ),
+    renamed as (
+        select
+            'miles&more-cc' as source,
+            parse_date('%d.%m.%Y',{{ adapter.quote("authorised_on") }}) as local_date,
+            'EUR' as local_currency,
+            safe_cast(
+                replace(
+                    replace({{ adapter.quote("amount") }}, '.', ''), ',', '.'
+                ) as float64
+            ) as local_amount,  -- convert european format
+            {{ adapter.quote("category") }},
+            trim({{ adapter.quote("description") }}) as description
+
+        from source
+    )
+select *
+from renamed


### PR DESCRIPTION
introducing source for miles&more (EUR, credit card)

stage external source to google sheet:
```sh
dbt run-operation stage_external_sources --args "select: google_sheets.de_eur_miles_more" --vars "ext_full_refresh: true"
```